### PR TITLE
.github/workflows/sphinx: Further fix branch names with '/' in them

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -82,3 +82,4 @@ jobs:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _gh-pages/
+          #force_orphan: true

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -25,6 +25,10 @@ jobs:
           pip install -r requirements.txt
       - name: Debugging information
         run: |
+          echo "github.ref:" ${{github.ref}}
+          echo "github.event_name:" ${{github.event_name}}
+          echo "github.head_ref:" ${{github.head_ref}}
+          echo "github.base_ref:" ${{github.base_ref}}
           git rev-parse --abbrev-ref HEAD
           git branch
           git branch -a
@@ -36,16 +40,22 @@ jobs:
         run: |
           make dirhtml
 
+
       # The following supports building all branches and combining on
       # gh-pages
+
+      # Clone and set up the old gh-pages branch
       - name: Clone old gh-pages
+        if: ${{ github.event_name == 'push' }}
         run: |
           set -x
           ( git branch gh-pages remotes/origin/gh-pages && git clone . --branch=gh-pages _gh-pages/ ) || mkdir _gh-pages
           rm -rf _gh-pages/.git/
           mkdir -p _gh-pages/branch/
+      # If a push and master, copy build to _gh-pages/ as the "main"
+      # deployment.
       - name: Copy new build (master)
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
           set -x
           # Delete everything under _gh-pages/ that is from the
@@ -54,19 +64,26 @@ jobs:
           # _gh-pages itself.
           find _gh-pages/ -mindepth 1 ! -path '_gh-pages/branch*' -delete
           rsync -a _build/dirhtml/ _gh-pages/
+      # If a push and not on master, then copy the build to
+      # _gh-pages/branch/$brname (transforming '/' into '--')
       - name: Copy new build (branch)
-        if: ${{ github.ref != 'refs/heads/master' }}
+        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/master' }}
         run: |
           set -x
-          brname=$(git rev-parse --abbrev-ref HEAD)
+          #brname=$(git rev-parse --abbrev-ref HEAD)
+          brname="${{github.ref}}"
+          brname="${brname##refs/heads/}"
           brdir=${brname//\//--}   # replace '/' with '--'
           rm -rf   _gh-pages/branch/${brdir}
           rsync -a _build/dirhtml/ _gh-pages/branch/${brdir}
+      # Go through each branch in _gh-pages/branch/, if it's not a
+      # ref, then delete it.
       - name: Delete old feature branches
+        if: ${{ github.event_name == 'push' }}
         run: |
           set -x
           for brdir in `ls _gh-pages/branch/` ; do
-              brname=${brname//--/\/}   # replace '--' with '/'
+              brname=${brdir//--/\/}   # replace '--' with '/'
               if ! git show-ref remotes/origin/$brname ; then
                   echo "Removing $brdir"
                   rm -r _gh-pages/branch/$brdir/
@@ -77,6 +94,7 @@ jobs:
       # https://github.com/peaceiris/actions-gh-pages
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' }}
         #if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         with:
           publish_branch: gh-pages

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -48,7 +48,11 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           set -x
-          find _gh-pages/ ! -mindepth 1 -path '_gh-pages/branch*' -delete
+          # Delete everything under _gh-pages/ that is from the
+          # primary branch deployment.  Eicludes the other branches
+          # _gh-pages/branch-* paths, and not including
+          # _gh-pages itself.
+          find _gh-pages/ -mindepth 1 ! -path '_gh-pages/branch*' -delete
           rsync -a _build/dirhtml/ _gh-pages/
       - name: Copy new build (branch)
         if: ${{ github.ref != 'refs/heads/master' }}

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -58,16 +58,18 @@ jobs:
         if: ${{ github.ref != 'refs/heads/master' }}
         run: |
           set -x
-          rm -rf   _gh-pages/branch/$(git rev-parse --abbrev-ref HEAD)
-          mkdir -p _gh-pages/branch/$(git rev-parse --abbrev-ref HEAD)
-          rsync -a _build/dirhtml/ _gh-pages/branch/$(git rev-parse --abbrev-ref HEAD)
+          brname=$(git rev-parse --abbrev-ref HEAD)
+          brdir=${brname//\//--}   # replace '/' with '--'
+          rm -rf   _gh-pages/branch/${brdir}
+          rsync -a _build/dirhtml/ _gh-pages/branch/${brdir}
       - name: Delete old feature branches
         run: |
           set -x
-          for brname in `ls _gh-pages/branch/` ; do
+          for brdir in `ls _gh-pages/branch/` ; do
+              brname=${brname//--/\/}   # replace '--' with '/'
               if ! git show-ref remotes/origin/$brname ; then
-                  echo "Removing $brname"
-                  rm -r _gh-pages/branch/$brname/
+                  echo "Removing $brdir"
+                  rm -r _gh-pages/branch/$brdir/
               fi
           done
 


### PR DESCRIPTION
- Encode a '/' as a '--' in the directory name.
- This isn't perfect (fails if there is already a double-dash), but
  better than before and good enough for now.
- Several other minor changes included.